### PR TITLE
Component refactor

### DIFF
--- a/addon/components/await/component.js
+++ b/addon/components/await/component.js
@@ -5,39 +5,46 @@ import { task } from 'ember-concurrency-decorators';
 import { addObserver, removeObserver } from '@ember/object/observers';
 
 class AwaitComponent extends Component {
+  @computed('promiseTask.last')
+  get lastPromiseTask() {
+    return this.promiseTask.last;
+  }
+
   @computed('promiseTask.performCount')
   get counter() {
-    return this.promiseTask.performCount
+    return this.promiseTask.performCount;
   }
 
-  @computed('promiseTask.last.value')
+  @computed('lastPromiseTask.value')
   get data() {
-    return this.promiseTask.last?.value
+    return this.lastPromiseTask?.value;
   }
 
-  @computed('promiseTask.last.error')
+  @computed('lastPromiseTask.error')
   get error() {
-    return this.promiseTask.last?.error
+    return this.lastPromiseTask?.error;
   }
 
   @computed('isRejected', 'error', 'data')
   get value() {
-    return this.isRejected ? this.error : this.data;
+    const { isRejected, error, data } = this;
+
+    return isRejected ? error : data;
   }
 
-  @computed('promiseTask.last.isSuccessful')
+  @computed('lastPromiseTask.isSuccessful')
   get isFulfilled() {
-    return !!this.promiseTask.last?.isSuccessful
+    return Boolean(this.lastPromiseTask?.isSuccessful);
   }
 
-  @computed('promiseTask.last.isError')
+  @computed('lastPromiseTask.isError')
   get isRejected() {
-    return !!this.promiseTask.last?.isError
+    return Boolean(this.lastPromiseTask?.isError);
   }
 
-  @computed('promiseTask.last.isFinished')
+  @computed('lastPromiseTask.isFinished')
   get isSettled() {
-    return !!this.promiseTask.last?.isFinished
+    return Boolean(this.lastPromiseTask?.isFinished);
   }
 
   @computed('counter')
@@ -51,8 +58,9 @@ class AwaitComponent extends Component {
   }
 
   constructor() {
-    super(...arguments)
-    addObserver(this, 'args.promise', this.resolvePromise)
+    super(...arguments);
+
+    addObserver(this, 'args.promise', this.resolvePromise);
 
     if (this.args.promise) {
       this.resolvePromise();
@@ -60,7 +68,7 @@ class AwaitComponent extends Component {
   }
 
   willDestroy() {
-    removeObserver(this, 'args.promise', this.resolvePromise)
+    removeObserver(this, 'args.promise', this.resolvePromise);
   }
 
   @task({ restartable: true })
@@ -78,7 +86,9 @@ class AwaitComponent extends Component {
 
   @action
   run() {
-    this.promiseTask.perform(this.args.defer)
+    const { promiseTask, args } = this;
+
+    promiseTask.perform(args.defer);
   }
 
   @action

--- a/addon/components/await/component.js
+++ b/addon/components/await/component.js
@@ -60,28 +60,20 @@ class AwaitComponent extends Component {
   constructor() {
     super(...arguments);
 
-    addObserver(this, 'args.promise', this.resolvePromise);
+    addObserver(this, 'args.promise', this._resolvePromise);
 
     if (this.args.promise) {
-      this.resolvePromise();
+      this._resolvePromise();
     }
   }
 
   willDestroy() {
-    removeObserver(this, 'args.promise', this.resolvePromise);
+    removeObserver(this, 'args.promise', this._resolvePromise);
   }
 
   @task({ restartable: true })
   *promiseTask(promise) {
-    return yield ((this.isFunction(promise) ? promise() : promise));
-  }
-
-  resolvePromise() {
-    return this.promiseTask.perform(this.args.promise);
-  }
-
-  isFunction(promise) {
-    return (typeof promise) === "function";
+    return yield ((this._isFunction(promise) ? promise() : promise));
   }
 
   @action
@@ -93,12 +85,20 @@ class AwaitComponent extends Component {
 
   @action
   reload() {
-    this.resolvePromise();
+    this._resolvePromise();
   }
 
   @action
   cancel() {
     this.promiseTask.cancelAll();
+  }
+
+  _resolvePromise() {
+    return this.promiseTask.perform(this.args.promise);
+  }
+
+  _isFunction(promise) {
+    return (typeof promise) === "function";
   }
 }
 

--- a/addon/components/await/state/template.hbs
+++ b/addon/components/await/state/template.hbs
@@ -1,3 +1,3 @@
-{{#if @if}}
+{{#if @shouldRender}}
   {{yield @value}}
 {{/if}}

--- a/addon/components/await/template.hbs
+++ b/addon/components/await/template.hbs
@@ -15,9 +15,9 @@
   cancel=this.cancel
   run=this.run
 
-  Pending=(component "await/state" if=this.isPending)
-  Fulfilled=(component "await/state" if=this.isFulfilled value=this.data)
-  Rejected=(component "await/state" if=this.isRejected value=this.error)
-  Settled=(component "await/state" if=this.isSettled)
-  Initial=(component "await/state" if=this.isInitial)
+  Pending=(component "await/state" shouldRender=this.isPending)
+  Fulfilled=(component "await/state" shouldRender=this.isFulfilled value=this.data)
+  Rejected=(component "await/state" shouldRender=this.isRejected value=this.error)
+  Settled=(component "await/state" shouldRender=this.isSettled)
+  Initial=(component "await/state" shouldRender=this.isInitial)
 )}}


### PR DESCRIPTION
Hi @Exelord I managed to do some refactor in the component and its template. All tests are green 🟢 but maybe you need to check it manually cause there is no dummy app yet.

I wanted to tag `isFunction` and `resolvePromise` as a private methods but that feature is still tagged as experimental and we need to add special Babel plugin first before playing with it  - in the plugins it may force the add-on users to install something extra so I decided to stick with the pseudo private methods.

Let me know what do you think about it.

Thanks!